### PR TITLE
Fixing error TS2717: Subsequent property declarations must have the s…

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -16,7 +16,7 @@
 declare global {
     interface String {
         reset: string;
-        bold: string;
+        bold: () => string;
         dim: string;
         italic: string;
         underline: string;


### PR DESCRIPTION
This PR will fix the error during build:
```
node_modules/colors.ts/lib/index.d.ts:19:9 - error TS2717: Subsequent property declarations must have the same type.  Property 'bold' must be of type '() => string', but here has type 'string'.

19         bold: string;
           ~~~~

  node_modules/typescript/lib/lib.es2015.core.d.ts:479:5
    479     bold(): string;
            ~~~~~~~~~~~~~~~
    'bold' was also declared here.


Found 1 error in node_modules/colors.ts/lib/index.d.ts:19
```